### PR TITLE
Make image links work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Roll the dependency on `markdown` to 1.0.0
 * Add a test and example for image links
+* Fix the `onTap` callback on hyperlinks
 
 ## 0.0.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+## 0.1.0
+
+* Roll the dependency on `markdown` to 1.0.0
+* Add a test and example for image links
+
+## 0.0.9
+
+* First published version

--- a/example/demo.dart
+++ b/example/demo.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 
-const String _kMarkdownData = """# Markdown Example
+const String _markdownData = """# Markdown Example
 Markdown allows you to easily include formatted text, images, and even formatted Dart code in your app.
 
 ## Styling
@@ -18,12 +18,33 @@ Style text as _italic_, __bold__, or `inline code`.
 ## Links
 You can use [hyperlinks](hyperlink) in markdown
 
-## Code blocks
-Formatted Dart code looks really pretty too. This is an example of how to create your own Markdown widget:
+## Images
+
+You can include images:
+
+![Flutter logo](https://flutter.io/images/flutter-mark-square-100.png)
+
+## Markdown widget
+
+This is an example of how to create your own Markdown widget:
 
     new Markdown(data: 'Hello _world_!');
 
+## Code blocks
+Formatted Dart code looks really pretty too:
+
+```
+void main() {
+  runApp(new MaterialApp(
+    home: new Scaffold(
+      body: new Markdown(data: markdownData)
+    )
+  ));
+}
+
 Enjoy!
+```
+
 """;
 
 void main() {
@@ -31,7 +52,7 @@ void main() {
     title: "Markdown Demo",
     home: new Scaffold(
       appBar: new AppBar(title: const Text('Markdown Demo')),
-      body: const Markdown(data: _kMarkdownData)
+      body: const Markdown(data: _markdownData)
     )
   ));
 }

--- a/example/demo.dart
+++ b/example/demo.dart
@@ -22,7 +22,7 @@ You can use [hyperlinks](hyperlink) in markdown
 
 You can include images:
 
-![Flutter logo](https://flutter.io/images/flutter-mark-square-100.png)
+![Flutter logo](https://flutter.io/images/flutter-mark-square-100.png#100x100)
 
 ## Markdown widget
 
@@ -41,10 +41,9 @@ void main() {
     )
   ));
 }
-
-Enjoy!
 ```
 
+Enjoy!
 """;
 
 void main() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,12 +2,12 @@ name: flutter_markdown
 author: Flutter Authors <flutter-dev@googlegroups.com>
 description: A markdown renderer for Flutter.
 homepage: https://github.com/flutter/flutter_markdown
-version: 0.0.10
+version: 0.1.0
 
 dependencies:
   flutter:
     sdk: flutter
-  markdown: ^0.11.0
+  markdown: ^1.0.0
   meta: ^1.0.5
   string_scanner: ^1.0.0
 

--- a/test/flutter_markdown_test.dart
+++ b/test/flutter_markdown_test.dart
@@ -90,11 +90,23 @@ void main() {
         .pumpWidget(_boilerplate(const Markdown(data: '[Link Text](href)')));
 
     final RichText textWidget =
-    tester.allWidgets.firstWhere((Widget widget) => widget is RichText);
+      tester.allWidgets.firstWhere((Widget widget) => widget is RichText);
     final TextSpan span = textWidget.text;
 
     expect(
         span.children[0].recognizer.runtimeType, equals(TapGestureRecognizer));
+  });
+
+  testWidgets('Image links', (WidgetTester tester) async {
+    await tester
+        .pumpWidget(_boilerplate(const Markdown(data: '![alt](img#50x50)')));
+
+    final Image image =
+      tester.allWidgets.firstWhere((Widget widget) => widget is Image);
+    final NetworkImage networkImage = image.image;
+    expect(networkImage.url, 'img');
+    expect(image.width, 50);
+    expect(image.height, 50);
   });
 
   testWidgets('HTML tag ignored ', (WidgetTester tester) async {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter_markdown/issues/3

In addition:

* Add changelog file
* Roll dependency on markdown to 1.0.0 (that contains the fix for image links; see https://github.com/dart-lang/markdown/pull/182)
* Add example and test for image links