### PR TITLE
Adds 'li' style to the _buildBullet function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.4
+
+* Add `li` style to bullets 
+
 ## 0.1.3
 
 * Add `path` and `http` as declared dependencies in `pubspec.yaml`

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -277,12 +277,12 @@ class MarkdownBuilder implements md.NodeVisitor {
 
   Widget _buildBullet(String listTag) {
     if (listTag == 'ul')
-      return const Text('•', textAlign: TextAlign.center);
+      return new Text('•', textAlign: TextAlign.center, style: styleSheet.styles['li']);
 
     final int index = _blocks.last.nextListIndex;
     return new Padding(
       padding: const EdgeInsets.only(right: 5.0),
-      child: new Text('${index + 1}.', textAlign: TextAlign.right),
+      child: new Text('${index + 1}.', textAlign: TextAlign.right, style: styleSheet.styles['li']),
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_markdown
 author: Flutter Authors <flutter-dev@googlegroups.com>
 description: A markdown renderer for Flutter.
 homepage: https://github.com/flutter/flutter_markdown
-version: 0.1.3
+version: 0.1.4
 
 dependencies:
   flutter:


### PR DESCRIPTION
Previously, the bullets built for lists were not using any specified text style.  This could lead to a mismatch in the look of the lists.  This PR updates them to be build with the style specified for `li`.