### PR TITLE
Add support for asset images

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ design, use the MarkdownRaw class.
 
 ## Image support
 
-The `Img` tag only supports the following image locations. It specifically
-does not support image locations referring to bundled assets.
+The `Img` tag only supports the following image locations:
 
 * From the network: Use a URL prefixed by either `http://` or `https://`.
 
@@ -35,3 +34,6 @@ does not support image locations referring to bundled assets.
   concatenating the file name with the path returned by a known storage location,
   such as those provided by the [`path_provider`](https://pub.dartlang.org/packages/path_provider)
   plugin.
+
+* From image locations referring to bundled assets: Use an asset name prefixed by `resource:`.
+  like `resource:assets/image.png`.

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -262,6 +262,8 @@ class MarkdownBuilder implements md.NodeVisitor {
       child = new Image.network(uri.toString(), width: width, height: height);
     } else if (uri.scheme == 'data') {
       child = _handleDataSchemeUri(uri, width, height);
+    } else if (uri.scheme == "resource") {
+      child = new Image.asset(path.substring(9), width: width, height: height);
     } else {
       String filePath = (imageDirectory == null
           ? uri.toFilePath()

--- a/test/flutter_markdown_test.dart
+++ b/test/flutter_markdown_test.dart
@@ -217,6 +217,16 @@ void main() {
       expect(image.image is FileImage, isTrue);
     });
 
+    testWidgets('should work with resources', (WidgetTester tester) async {
+      await tester.pumpWidget(_boilerplate(
+          const Markdown(data: '![alt](resource:assets/logo.png)')));
+
+      final Image image =
+        tester.allWidgets.firstWhere((Widget widget) => widget is Image);
+      expect(image.image is AssetImage, isTrue);
+      expect((image.image as AssetImage).assetName == 'assets/logo.png', isTrue);
+    });
+
     testWidgets('should work with local image files', (WidgetTester tester) async {
       await tester
           .pumpWidget(_boilerplate(const Markdown(data: '![alt](img.png#50x50)')));


### PR DESCRIPTION
Allows to use a flutter asset as image source:
```
![alt text](asset://assets/image.png)
```
