### PR TITLE
Add textScaleFactor to stylesheet/RichText widgets

### DIFF
--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -136,7 +136,10 @@ class MarkdownBuilder implements md.NodeVisitor {
           recognizer: _linkHandlers.isNotEmpty ? _linkHandlers.last : null,
         );
 
-    _inlines.last.children.add(new RichText(text: span));
+    _inlines.last.children.add(new RichText(
+      textScaleFactor: styleSheet.textScaleFactor,
+      text: span,
+    ));
   }
 
   @override
@@ -336,11 +339,14 @@ class MarkdownBuilder implements md.NodeVisitor {
       if (mergedTexts.isNotEmpty && mergedTexts.last is RichText && child is RichText) {
         RichText previous = mergedTexts.removeLast();
         List<TextSpan> children = previous.text.children != null
-          ? new List.from(previous.text.children)
-          : [previous.text];
+            ? new List.from(previous.text.children)
+            : [previous.text];
         children.add(child.text);
         TextSpan mergedSpan = new TextSpan(children: children);
-        mergedTexts.add(new RichText(text: mergedSpan));
+        mergedTexts.add(new RichText(
+          textScaleFactor: styleSheet.textScaleFactor,
+          text: mergedSpan,
+        ));
       } else {
         mergedTexts.add(child);
       }

--- a/lib/src/style_sheet.dart
+++ b/lib/src/style_sheet.dart
@@ -27,7 +27,8 @@ class MarkdownStyleSheet {
     this.blockquoteDecoration,
     this.codeblockPadding,
     this.codeblockDecoration,
-    this.horizontalRuleDecoration
+    this.horizontalRuleDecoration,
+    this.textScaleFactor = 1.0
   }) : _styles = <String, TextStyle>{
     'a': a,
     'p': p,
@@ -152,7 +153,8 @@ class MarkdownStyleSheet {
     Decoration blockquoteDecoration,
     double codeblockPadding,
     Decoration codeblockDecoration,
-    Decoration horizontalRuleDecoration
+    Decoration horizontalRuleDecoration,
+    double textScaleFactor,
   }) {
     return new MarkdownStyleSheet(
       a: a ?? this.a,
@@ -175,6 +177,7 @@ class MarkdownStyleSheet {
       codeblockPadding: codeblockPadding ?? this.codeblockPadding,
       codeblockDecoration: codeblockDecoration ?? this.codeblockDecoration,
       horizontalRuleDecoration: horizontalRuleDecoration ?? this.horizontalRuleDecoration,
+      textScaleFactor : textScaleFactor ?? this.textScaleFactor,
     );
   }
 
@@ -238,6 +241,9 @@ class MarkdownStyleSheet {
   /// The decoration to use for `hr` elements.
   final Decoration horizontalRuleDecoration;
 
+  // The text scale factor to use in textual elements
+  final double textScaleFactor;
+
   /// A [Map] from element name to the corresponding [TextStyle] object.
   Map<String, TextStyle> get styles => _styles;
   Map<String, TextStyle> _styles;
@@ -268,12 +274,13 @@ class MarkdownStyleSheet {
         && typedOther.blockquoteDecoration == blockquoteDecoration
         && typedOther.codeblockPadding == codeblockPadding
         && typedOther.codeblockDecoration == codeblockDecoration
-        && typedOther.horizontalRuleDecoration == horizontalRuleDecoration;
+        && typedOther.horizontalRuleDecoration == horizontalRuleDecoration
+        && typedOther.textScaleFactor == textScaleFactor;
   }
 
   @override
   int get hashCode {
-    return hashValues(
+    return hashList([
       a,
       p,
       code,
@@ -294,6 +301,7 @@ class MarkdownStyleSheet {
       codeblockPadding,
       codeblockDecoration,
       horizontalRuleDecoration,
-    );
+      textScaleFactor,
+    ]);
   }
 }

--- a/test/flutter_markdown_test.dart
+++ b/test/flutter_markdown_test.dart
@@ -450,6 +450,19 @@ void main() {
     expect(style1, equals(style2));
     expect(style1.hashCode, equals(style2.hashCode));
   });
+
+  testWidgets('should use style textScaleFactor in RichText', (WidgetTester tester) async {
+    await tester.pumpWidget(_boilerplate(
+      MarkdownBody(
+        styleSheet: MarkdownStyleSheet(textScaleFactor: 2.0),
+        data: 'Hello',
+      ),
+    ));
+
+    final RichText richText =
+    tester.allWidgets.firstWhere((Widget widget) => widget is RichText);
+    expect(richText.textScaleFactor, 2.0);
+  });
 }
 
 void _expectWidgetTypes(Iterable<Widget> widgets, List<Type> expected) {


### PR DESCRIPTION
Adds the ability to adjust the `textScaleFactor` of the `RichText` widgets (used by textual elements of the Markdown) using the stylesheet.

This is useful for the accessibility, when the text has to scale based on the device's font size preference.


