### PR TITLE
URIs with GET parameters don't work inside Markdown body

### DIFF
--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -257,11 +257,11 @@ class MarkdownBuilder implements md.NodeVisitor {
     }
 
     Uri uri = Uri.parse(path);
+    uri = uri.replace(query: uri.query.replaceAll('&amp;', '&'));
     Widget child;
     if (uri.scheme == 'http' || uri.scheme == 'https') {
       child = new Image.network(uri.toString(), width: width, height: height);
     } else if (uri.scheme == 'data') {
-      uri = uri.replace(query: uri.query.replaceAll('&amp;', '&'));
       child = _handleDataSchemeUri(uri, width, height);
     } else if (uri.scheme == "resource") {
       child = new Image.asset(path.substring(9), width: width, height: height);

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -261,6 +261,7 @@ class MarkdownBuilder implements md.NodeVisitor {
     if (uri.scheme == 'http' || uri.scheme == 'https') {
       child = new Image.network(uri.toString(), width: width, height: height);
     } else if (uri.scheme == 'data') {
+      uri = uri.replace(query: uri.query.replaceAll('&amp;', '&'));
       child = _handleDataSchemeUri(uri, width, height);
     } else if (uri.scheme == "resource") {
       child = new Image.asset(path.substring(9), width: width, height: height);

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -257,10 +257,9 @@ class MarkdownBuilder implements md.NodeVisitor {
     }
 
     Uri uri = Uri.parse(path);
-    uri = uri.replace(query: uri.query.replaceAll('&amp;', '&'));
     Widget child;
     if (uri.scheme == 'http' || uri.scheme == 'https') {
-      child = new Image.network(uri.toString(), width: width, height: height);
+      child = new Image.network(uri, width: width, height: height);
     } else if (uri.scheme == 'data') {
       child = _handleDataSchemeUri(uri, width, height);
     } else if (uri.scheme == "resource") {


### PR DESCRIPTION
If you have a markdown body like this 
```
Misbehaving macbook
![Screen Shot 2019-03-19 at 8.50.02 AM.png](https://some-s3-url/md5/b8d/5fb/4cff6fa34ef12505b72862fb76/23211cd7-347a-48ff-9627-4b2b27d7845b.png?Signature=b4TjWT%2Bal0DU%2BPZqo%2BR9p70b4K4%3D&Expires=1553008915&AWSAccessKeyId=ACCESS_KEY_ID)
```

The current code turns this into 
```
Misbehaving macbook
![Screen Shot 2019-03-19 at 8.50.02 AM.png](https://some-s3-url/md5/b8d/5fb/4cff6fa34ef12505b72862fb76/23211cd7-347a-48ff-9627-4b2b27d7845b.png?Signature=b4TjWT%2Bal0DU%2BPZqo%2BR9p70b4K4%3D&amp;Expires=1553008915&amp;AWSAccessKeyId=ACCESS_KEY_ID)
```

That's because of the `toString` call, which is now removed. If there are tests here that you'd like to see, I am happy to write those, but since we are just passing `uri` (which has tests) to `Image.network` which also has tests -- I am hoping that's not necessary. 

Feel free to squash commits, as it took me a few tries to figure out the problem. 