### PR TITLE
Convert TextSpan usage to new InlineSpan API

### DIFF
--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -340,9 +340,10 @@ class MarkdownBuilder implements md.NodeVisitor {
     for (Widget child in inline.children) {
       if (mergedTexts.isNotEmpty && mergedTexts.last is RichText && child is RichText) {
         RichText previous = mergedTexts.removeLast();
-        List<TextSpan> children = previous.text.children != null
-            ? new List.from(previous.text.children)
-            : [previous.text];
+        TextSpan previousTextSpan = previous.text;
+        List<TextSpan> children = previousTextSpan.children != null
+            ? new List.from(previousTextSpan.children)
+            : [previousTextSpan];
         children.add(child.text);
         TextSpan mergedSpan = new TextSpan(children: children);
         mergedTexts.add(new RichText(

--- a/test/flutter_markdown_test.dart
+++ b/test/flutter_markdown_test.dart
@@ -128,8 +128,7 @@ void main() {
       final TextSpan span = textWidget.text;
 
       final List<Type> gestureRecognizerTypes = <Type>[];
-      span.visitChildren((InlineSpan inlineSpan) {
-        final TextSpan textSpan = inlineSpan;
+      span.visitTextSpan((TextSpan textSpan) {
         TapGestureRecognizer recognizer = textSpan.recognizer;
         gestureRecognizerTypes.add(recognizer.runtimeType);
         recognizer.onTap();
@@ -156,8 +155,7 @@ void main() {
       final TextSpan span = textWidget.text;
 
       final List<Type> gestureRecognizerTypes = <Type>[];
-      span.visitChildren((InlineSpan inlineSpan) {
-        final TextSpan textSpan = inlineSpan;
+      span.visitTextSpan((TextSpan textSpan) {
         TapGestureRecognizer recognizer = textSpan.recognizer;
         gestureRecognizerTypes.add(recognizer.runtimeType);
         recognizer?.onTap();

--- a/test/flutter_markdown_test.dart
+++ b/test/flutter_markdown_test.dart
@@ -128,7 +128,8 @@ void main() {
       final TextSpan span = textWidget.text;
 
       final List<Type> gestureRecognizerTypes = <Type>[];
-      span.visitTextSpan((TextSpan textSpan) {
+      span.visitChildren((InlineSpan inlineSpan) {
+        final TextSpan textSpan = inlineSpan;
         TapGestureRecognizer recognizer = textSpan.recognizer;
         gestureRecognizerTypes.add(recognizer.runtimeType);
         recognizer.onTap();
@@ -155,7 +156,8 @@ void main() {
       final TextSpan span = textWidget.text;
 
       final List<Type> gestureRecognizerTypes = <Type>[];
-      span.visitTextSpan((TextSpan textSpan) {
+      span.visitChildren((InlineSpan inlineSpan) {
+        final TextSpan textSpan = inlineSpan;
         TapGestureRecognizer recognizer = textSpan.recognizer;
         gestureRecognizerTypes.add(recognizer.runtimeType);
         recognizer?.onTap();
@@ -183,17 +185,19 @@ void main() {
 
       final RichText firstTextWidget =
           tester.allWidgets.firstWhere((Widget widget) => widget is RichText);
+      final TextSpan firstTextSpan = firstTextWidget.text;
       final Image image =
           tester.allWidgets.firstWhere((Widget widget) => widget is Image);
       final NetworkImage networkImage = image.image;
       final RichText secondTextWidget =
           tester.allWidgets.lastWhere((Widget widget) => widget is RichText);
+      final TextSpan secondTextSpan = secondTextWidget.text;
 
-      expect(firstTextWidget.text.text, 'textbefore ');
-      expect(firstTextWidget.text.style.fontStyle, FontStyle.italic);
+      expect(firstTextSpan.text, 'textbefore ');
+      expect(firstTextSpan.style.fontStyle, FontStyle.italic);
       expect(networkImage.url,'http://img');
-      expect(secondTextWidget.text.text, ' textafter');
-      expect(secondTextWidget.text.style.fontStyle, FontStyle.italic);
+      expect(secondTextSpan.text, ' textafter');
+      expect(secondTextSpan.style.fontStyle, FontStyle.italic);
     });
 
     testWidgets('should work with a link', (WidgetTester tester) async {


### PR DESCRIPTION
This PR fixes for breaking changes, from the new `InlineSpan` inheritance structure, introduced in Flutter master with https://github.com/flutter/flutter/pull/33794.

I'm not sure how the Flutter team currently handles breaking changes with first-party plugins, however the Flutter version constraint in `pubspec.yaml` and version would also need to be bumped as the new API is only introduced in `Flutter 1.7.2-pre.12`. 