### PR TITLE
allow textAlign to be customized

### DIFF
--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -137,6 +137,7 @@ class MarkdownBuilder implements md.NodeVisitor {
         );
 
     _inlines.last.children.add(new RichText(
+      textAlign: styleSheet.textAlign,
       textScaleFactor: styleSheet.textScaleFactor,
       text: span,
     ));
@@ -347,6 +348,7 @@ class MarkdownBuilder implements md.NodeVisitor {
         children.add(child.text);
         TextSpan mergedSpan = new TextSpan(children: children);
         mergedTexts.add(new RichText(
+          textAlign: styleSheet.textAlign,
           textScaleFactor: styleSheet.textScaleFactor,
           text: mergedSpan,
         ));

--- a/lib/src/style_sheet.dart
+++ b/lib/src/style_sheet.dart
@@ -28,6 +28,7 @@ class MarkdownStyleSheet {
     this.codeblockPadding,
     this.codeblockDecoration,
     this.horizontalRuleDecoration,
+    this.textAlign = TextAlign.start,
     this.textScaleFactor = 1.0
   }) : _styles = <String, TextStyle>{
     'a': a,
@@ -154,6 +155,7 @@ class MarkdownStyleSheet {
     double codeblockPadding,
     Decoration codeblockDecoration,
     Decoration horizontalRuleDecoration,
+    TextAlign textAlign,
     double textScaleFactor,
   }) {
     return new MarkdownStyleSheet(
@@ -177,6 +179,7 @@ class MarkdownStyleSheet {
       codeblockPadding: codeblockPadding ?? this.codeblockPadding,
       codeblockDecoration: codeblockDecoration ?? this.codeblockDecoration,
       horizontalRuleDecoration: horizontalRuleDecoration ?? this.horizontalRuleDecoration,
+      textAlign : textAlign ?? this.textAlign,
       textScaleFactor : textScaleFactor ?? this.textScaleFactor,
     );
   }
@@ -241,6 +244,9 @@ class MarkdownStyleSheet {
   /// The decoration to use for `hr` elements.
   final Decoration horizontalRuleDecoration;
 
+
+  final TextAlign textAlign;
+
   // The text scale factor to use in textual elements
   final double textScaleFactor;
 
@@ -275,6 +281,7 @@ class MarkdownStyleSheet {
         && typedOther.codeblockPadding == codeblockPadding
         && typedOther.codeblockDecoration == codeblockDecoration
         && typedOther.horizontalRuleDecoration == horizontalRuleDecoration
+        && typedOther.textAlign == textAlign
         && typedOther.textScaleFactor == textScaleFactor;
   }
 
@@ -301,6 +308,7 @@ class MarkdownStyleSheet {
       codeblockPadding,
       codeblockDecoration,
       horizontalRuleDecoration,
+      textAlign,
       textScaleFactor,
     ]);
   }

--- a/test/flutter_markdown_test.dart
+++ b/test/flutter_markdown_test.dart
@@ -467,6 +467,19 @@ void main() {
     expect(style1.hashCode, equals(style2.hashCode));
   });
 
+  testWidgets('should use style textAlign in RichText', (WidgetTester tester) async {
+    await tester.pumpWidget(_boilerplate(
+      MarkdownBody(
+        styleSheet: MarkdownStyleSheet(textAlign: TextAlign.justify),
+        data: 'Hello World',
+      ),
+    ));
+
+    final RichText richText =
+    tester.allWidgets.firstWhere((Widget widget) => widget is RichText);
+    expect(richText.textAlign, TextAlign.justify);
+  });
+
   testWidgets('should use style textScaleFactor in RichText', (WidgetTester tester) async {
     await tester.pumpWidget(_boilerplate(
       MarkdownBody(


### PR DESCRIPTION
This enable users of flutter markdown to have the text rendered for instance justified or centered.