### PR TITLE
put RichText in Container

### DIFF
--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -136,10 +136,11 @@ class MarkdownBuilder implements md.NodeVisitor {
           recognizer: _linkHandlers.isNotEmpty ? _linkHandlers.last : null,
         );
 
-    _inlines.last.children.add(new RichText(
+    _inlines.last.children.add(new Container(
+      child:RichText(
       textScaleFactor: styleSheet.textScaleFactor,
       text: span,
-    ));
+    )));
   }
 
   @override


### PR DESCRIPTION
if you make hyperlinks in List, for example,

\*  \[s](https://www.google.com)  aaaaaaaaa
\*  \[s](https://www.google.com)  aaaaaaaaabbbbbb

It should be

*  [s](https://www.google.com)  aaaaaaaaa
*  [s](https://www.google.com)  aaaaaaaaaabbbbbb

However, the second line only shows as long as first line. So the 'bbbbbbb' part doesn't show up.
It can be solved by putting RichText (in visitText func in the 'builder.dart') into a Container widget.
*Tested in Chrome Browser