### PR TITLE
If markdown's has syntax error, the parser would throw error.

### DIFF
--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -233,6 +233,9 @@ class MarkdownBuilder implements md.NodeVisitor {
         _listIndents.removeLast();
       } else if (tag == 'li') {
         if (_listIndents.isNotEmpty) {
+         if (element.children.length == 0) {
+            return;
+          }
           Widget bullet;
           dynamic el = element.children[0];
           if (el is md.Element && el.attributes['type'] == 'checkbox') {


### PR DESCRIPTION
I got an issue with following invalid markdown syntax:
```markdown
- 
- a
- b
```

For the current implementation, this will throw an index out of range error because the first list item doesn't have an item. With the changes I have above, this will ignore the invalid markdown syntax.