### PR TITLE
Use .allWidgets.where pattern to test Image

### DIFF
--- a/test/flutter_markdown_test.dart
+++ b/test/flutter_markdown_test.dart
@@ -616,8 +616,9 @@ void main() {
 
       await tester.pumpWidget(_boilerplate(Markdown(data: data, imageBuilder: builder)));
 
-      final Image image = tester.widget(find.byType(Image));
-
+      final Iterable<Widget> widgets = tester.allWidgets;
+      final Image image = widgets.firstWhere((Widget widget) => widget is Image);
+      
       expect(image.image.runtimeType, AssetImage);
       expect((image.image as AssetImage).assetName, 'assets/logo.png');
     });


### PR DESCRIPTION
For whatever reason, this test fails in our internal environment if we use the type finder directly. Many of the other tests use the `allWidget.where()` pattern so I changed the Image test to that as well.