### PR TITLE
New test for a three hyphen Horizontal Rule

### DIFF
--- a/test/flutter_markdown_test.dart
+++ b/test/flutter_markdown_test.dart
@@ -139,8 +139,15 @@ void main() {
     ]);
   });
 
-  testWidgets('Horizontal Rule', (WidgetTester tester) async {
+  testWidgets('Horizontal Rule - five hyphen', (WidgetTester tester) async {
     await tester.pumpWidget(_boilerplate(const MarkdownBody(data: '-----')));
+
+    final Iterable<Widget> widgets = tester.allWidgets;
+    _expectWidgetTypes(widgets, <Type>[Directionality, MarkdownBody, DecoratedBox, SizedBox]);
+  });
+  
+  testWidgets('Horizontal Rule - three hyphen', (WidgetTester tester) async {
+    await tester.pumpWidget(_boilerplate(const MarkdownBody(data: '---')));
 
     final Iterable<Widget> widgets = tester.allWidgets;
     _expectWidgetTypes(widgets, <Type>[Directionality, MarkdownBody, DecoratedBox, SizedBox]);

--- a/test/flutter_markdown_test.dart
+++ b/test/flutter_markdown_test.dart
@@ -139,15 +139,23 @@ void main() {
     ]);
   });
 
-  testWidgets('Horizontal Rule - five hyphen', (WidgetTester tester) async {
-    await tester.pumpWidget(_boilerplate(const MarkdownBody(data: '-----')));
+  testWidgets('Horizontal Rule - 3 hyphen', (WidgetTester tester) async {
+
+    await tester.pumpWidget(
+      _boilerplate(const MarkdownBody(
+        data: '---'))
+    );
 
     final Iterable<Widget> widgets = tester.allWidgets;
     _expectWidgetTypes(widgets, <Type>[Directionality, MarkdownBody, DecoratedBox, SizedBox]);
   });
   
-  testWidgets('Horizontal Rule - three hyphen', (WidgetTester tester) async {
-    await tester.pumpWidget(_boilerplate(const MarkdownBody(data: '---')));
+  testWidgets('Horizontal Rule - 5 hyphen', (WidgetTester tester) async {
+
+    await tester.pumpWidget(
+      _boilerplate(const MarkdownBody(
+        data: '-----'))
+    );
 
     final Iterable<Widget> widgets = tester.allWidgets;
     _expectWidgetTypes(widgets, <Type>[Directionality, MarkdownBody, DecoratedBox, SizedBox]);


### PR DESCRIPTION
Just adding a new test for a three hyphen Horizontal Rule. 

It would be good to test this as it is a common MD format, and also one generated by https://pub.dev/packages/html2md