### PR TITLE
Fix for hr (horizontal rule) when alongside other markup (#201)

### DIFF
--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -297,9 +297,8 @@ class MarkdownBuilder implements md.NodeVisitor {
           child: child,
         );
       } else if (tag == 'hr') {
-        child = DecoratedBox(
-          decoration: styleSheet.horizontalRuleDecoration,
-          child: child,
+        child = Container(
+          decoration: styleSheet.horizontalRuleDecoration
         );
       }
 

--- a/test/flutter_markdown_test.dart
+++ b/test/flutter_markdown_test.dart
@@ -139,11 +139,87 @@ void main() {
     ]);
   });
 
-  testWidgets('Horizontal Rule', (WidgetTester tester) async {
-    await tester.pumpWidget(_boilerplate(const MarkdownBody(data: '-----')));
+  testWidgets('Horizontal Rule - 3 hyphen', (WidgetTester tester) async {
+
+    await tester.pumpWidget(
+      _boilerplate(MarkdownBody(
+        data: '---'))
+    );
 
     final Iterable<Widget> widgets = tester.allWidgets;
-    _expectWidgetTypes(widgets, <Type>[Directionality, MarkdownBody, DecoratedBox, SizedBox]);
+    _expectWidgetTypes(widgets, <Type>[
+      Directionality,
+      MarkdownBody,
+      Container,
+      DecoratedBox,
+      Padding,
+      LimitedBox,
+      ConstrainedBox
+    ]);
+
+  });
+
+  testWidgets('Horizontal Rule - 5 hyphen', (WidgetTester tester) async {
+
+    await tester.pumpWidget(
+      _boilerplate(MarkdownBody(
+        data: '-----'))
+    );
+
+    final Iterable<Widget> widgets = tester.allWidgets;
+    _expectWidgetTypes(widgets, <Type>[
+      Directionality,
+      MarkdownBody,
+      Container,
+      DecoratedBox,
+      Padding,
+      LimitedBox,
+      ConstrainedBox
+    ]);
+
+  });
+
+  testWidgets('Horizontal Rule - 3 asterisk', (WidgetTester tester) async {
+
+    await tester.pumpWidget(
+      _boilerplate(MarkdownBody(
+        data: '* * *'))
+    );
+
+    final Iterable<Widget> widgets = tester.allWidgets;
+    _expectWidgetTypes(widgets, <Type>[
+      Directionality,
+      MarkdownBody,
+      Container,
+      DecoratedBox,
+      Padding,
+      LimitedBox,
+      ConstrainedBox
+    ]);
+
+  });  
+  
+  testWidgets('Horizontal Rule * * * alongside text Markdown', (WidgetTester tester) async {    
+    await tester.pumpWidget(_boilerplate(
+      MarkdownBody(data: '# h1\n ## h2\n* * *')));
+    final Iterable<Widget> widgets = tester.allWidgets;
+    _expectWidgetTypes(widgets, <Type>[
+      Directionality,
+      MarkdownBody,
+      Column,
+      Column,
+      Wrap,
+      RichText,
+      SizedBox,
+      Column,
+      Wrap,
+      RichText,
+      SizedBox,
+      Container,
+      DecoratedBox,
+      Padding,
+      LimitedBox,
+      ConstrainedBox]);
   });
 
   testWidgets('Scrollable wrapping', (WidgetTester tester) async {


### PR DESCRIPTION
Fix for displaying hr. Previously would only work if the data field contained nothing but hr markdown - any additional markdown made it disappear. (#201)