### PR TITLE
Add compressionState to mock to avoid test failure

### DIFF
--- a/test/utils.dart
+++ b/test/utils.dart
@@ -183,6 +183,8 @@ MockHttpClient createMockImageHttpClient(io.SecurityContext _) {
       .thenAnswer((_) => Future<io.HttpClientResponse>.value(response));
   when(response.contentLength).thenReturn(_transparentImage.length);
   when(response.statusCode).thenReturn(io.HttpStatus.ok);
+  when(response.compressionState)
+      .thenReturn(io.HttpClientResponseCompressionState.notCompressed);
   when(response.listen(any)).thenAnswer((Invocation invocation) {
     final void Function(List<int>) onData = invocation.positionalArguments[0];
     final void Function() onDone = invocation.namedArguments[#onDone];


### PR DESCRIPTION
A recent change to the Dart SDK will throw an exception if a null value is passed to an exhaustive switch statement on a non-nullable enum type.
(see dart-lang/sdk@2414b29)

Add `compressionState` to mock so that the tests don't fail when the Dart changes are released.

Related issue: https://github.com/flutter/flutter/issues/66674