### PR TITLE
add empty text child for a if [](https://...) is provided

### DIFF
--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -203,6 +203,20 @@ class MarkdownBuilder implements md.NodeVisitor {
       if (start != null) bElement.nextListIndex = start;
       _blocks.add(bElement);
     } else {
+      if (tag == 'a') {
+        String text = extractTextFromElement(element);
+        // Don't add empty links
+        if (text == null) {
+          return false;
+        }
+        String destination = element.attributes['href'];
+        String title = element.attributes['title'] ?? "";
+
+        _linkHandlers.add(
+          delegate.createLink(text, destination, title),
+        );
+      }
+
       _addParentInlineIfNeeded(_blocks.last.tag);
 
       TextStyle parentStyle = _inlines.last.style;
@@ -210,20 +224,6 @@ class MarkdownBuilder implements md.NodeVisitor {
         tag,
         style: parentStyle.merge(styleSheet.styles[tag]),
       ));
-    }
-
-    if (tag == 'a') {
-      // Add empty child text if link is provided without value
-      if (element.children.isEmpty) {
-        element.children.add(md.Text(''));
-      }
-      String text = extractTextFromElement(element);
-      String destination = element.attributes['href'];
-      String title = element.attributes['title'] ?? "";
-
-      _linkHandlers.add(
-        delegate.createLink(text, destination, title),
-      );
     }
 
     return true;

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -213,6 +213,10 @@ class MarkdownBuilder implements md.NodeVisitor {
     }
 
     if (tag == 'a') {
+      // Add empty child text if link is provided without value
+      if (element.children.isEmpty) {
+        element.children.add(md.Text(''));
+      }
       String text = extractTextFromElement(element);
       String destination = element.attributes['href'];
       String title = element.attributes['title'] ?? "";

--- a/test/link_test.dart
+++ b/test/link_test.dart
@@ -127,6 +127,8 @@ void defineTests() {
             ),
           ),
         );
+
+        expectValidLink('');
       },
     );
 

--- a/test/link_test.dart
+++ b/test/link_test.dart
@@ -120,15 +120,19 @@ void defineTests() {
       'empty inline link',
       (WidgetTester tester) async {
         const String data = '[](/uri "title")';
+        MarkdownLink linkTapResults;
         await tester.pumpWidget(
           boilerplate(
             MarkdownBody(
               data: data,
+              onTapLink: (text, href, title) =>
+                  linkTapResults = MarkdownLink(text, href, title),
             ),
           ),
         );
 
         expectValidLink('');
+        expectLinkTap(linkTapResults, MarkdownLink('', '/uri', 'title'));
       },
     );
 

--- a/test/link_test.dart
+++ b/test/link_test.dart
@@ -117,6 +117,20 @@ void defineTests() {
     );
 
     testWidgets(
+      'empty inline link',
+      (WidgetTester tester) async {
+        const String data = '[](/uri "title")';
+        await tester.pumpWidget(
+          boilerplate(
+            MarkdownBody(
+              data: data,
+            ),
+          ),
+        );
+      },
+    );
+
+    testWidgets(
       // Example 494 from GFM.
       'simple inline link - title omitted',
       (WidgetTester tester) async {

--- a/test/link_test.dart
+++ b/test/link_test.dart
@@ -131,8 +131,8 @@ void defineTests() {
           ),
         );
 
-        expectValidLink('');
-        expectLinkTap(linkTapResults, MarkdownLink('', '/uri', 'title'));
+        expect(find.byType(RichText), findsNothing);
+        expect(linkTapResults, isNull);
       },
     );
 


### PR DESCRIPTION
I used this package as a dependency for my [flutter_markdown_editor](https://github.com/ammaratef45/flutter_markdown_editor), I noticed that when the user inserts `[](https://...)` it throws an exception (that can happen quite often while editing as the user might keep deleting and writing the text inside `[]`

I've added an empty `Text` element as a child for the `a` element with empty children.

I've also added a test to check if it doesn't throw any exceptions when that is the case.

Hope it helps 😸 