### PR TITLE
Add stylesheet option listBulletPadding

### DIFF
--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -459,10 +459,13 @@ class MarkdownBuilder implements md.NodeVisitor {
 
   Widget _buildBullet(String listTag) {
     if (listTag == 'ul') {
-      return Text(
-        '•',
-        textAlign: TextAlign.center,
-        style: styleSheet.listBullet,
+      return Padding(
+        padding: styleSheet.listBulletPadding,
+        child: Text(
+          '•',
+          textAlign: TextAlign.center,
+          style: styleSheet.listBullet,
+        ),
       );
     }
 

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -324,7 +324,9 @@ class MarkdownBuilder implements md.NodeVisitor {
             crossAxisAlignment: CrossAxisAlignment.baseline,
             children: <Widget>[
               SizedBox(
-                width: styleSheet.listIndent,
+                width: styleSheet.listIndent +
+                    styleSheet.listBulletPadding.left +
+                    styleSheet.listBulletPadding.right,
                 child: bullet,
               ),
               Expanded(child: child)
@@ -446,7 +448,7 @@ class MarkdownBuilder implements md.NodeVisitor {
       return checkboxBuilder(checked);
     }
     return Padding(
-      padding: const EdgeInsets.only(right: 4),
+      padding: styleSheet.listBulletPadding,
       child: Icon(
         checked ? Icons.check_box : Icons.check_box_outline_blank,
         size: styleSheet.checkbox.fontSize,
@@ -466,7 +468,7 @@ class MarkdownBuilder implements md.NodeVisitor {
 
     final int index = _blocks.last.nextListIndex;
     return Padding(
-      padding: const EdgeInsets.only(right: 4),
+      padding: styleSheet.listBulletPadding,
       child: Text(
         '${index + 1}.',
         textAlign: TextAlign.right,

--- a/lib/src/style_sheet.dart
+++ b/lib/src/style_sheet.dart
@@ -27,6 +27,7 @@ class MarkdownStyleSheet {
     this.blockSpacing,
     this.listIndent,
     this.listBullet,
+    this.listBulletPadding,
     this.tableHead,
     this.tableBody,
     this.tableHeadAlign,
@@ -102,6 +103,7 @@ class MarkdownStyleSheet {
       blockSpacing: 8.0,
       listIndent: 24.0,
       listBullet: theme.textTheme.bodyText2,
+      listBulletPadding: const EdgeInsets.only(right: 4),
       tableHead: const TextStyle(fontWeight: FontWeight.w600),
       tableBody: theme.textTheme.bodyText2,
       tableHeadAlign: TextAlign.center,
@@ -190,6 +192,7 @@ class MarkdownStyleSheet {
       blockSpacing: 8,
       listIndent: 24,
       listBullet: theme.textTheme.textStyle,
+      listBulletPadding: const EdgeInsets.only(right: 4),
       tableHead: theme.textTheme.textStyle.copyWith(
         fontWeight: FontWeight.w600,
       ),
@@ -266,6 +269,7 @@ class MarkdownStyleSheet {
       blockSpacing: 8.0,
       listIndent: 24.0,
       listBullet: theme.textTheme.bodyText2,
+      listBulletPadding: const EdgeInsets.only(right: 4),
       tableHead: const TextStyle(fontWeight: FontWeight.w600),
       tableBody: theme.textTheme.bodyText2,
       tableHeadAlign: TextAlign.center,
@@ -317,6 +321,7 @@ class MarkdownStyleSheet {
     double blockSpacing,
     double listIndent,
     TextStyle listBullet,
+    EdgeInsets listBulletPadding,
     TextStyle tableHead,
     TextStyle tableBody,
     TextAlign tableHeadAlign,
@@ -361,6 +366,7 @@ class MarkdownStyleSheet {
       blockSpacing: blockSpacing ?? this.blockSpacing,
       listIndent: listIndent ?? this.listIndent,
       listBullet: listBullet ?? this.listBullet,
+      listBulletPadding: listBulletPadding ?? this.listBulletPadding,
       tableHead: tableHead ?? this.tableHead,
       tableBody: tableBody ?? this.tableBody,
       tableHeadAlign: tableHeadAlign ?? this.tableHeadAlign,
@@ -412,6 +418,7 @@ class MarkdownStyleSheet {
       blockSpacing: other.blockSpacing,
       listIndent: other.listIndent,
       listBullet: listBullet.merge(other.listBullet),
+      listBulletPadding: other.listBulletPadding,
       tableHead: tableHead.merge(other.tableHead),
       tableBody: tableBody.merge(other.tableBody),
       tableHeadAlign: other.tableHeadAlign,
@@ -492,6 +499,9 @@ class MarkdownStyleSheet {
 
   /// The [TextStyle] to use for bullets.
   final TextStyle listBullet;
+
+  /// The padding to use for bullets.
+  final EdgeInsets listBulletPadding;
 
   /// The [TextStyle] to use for `th` elements.
   final TextStyle tableHead;
@@ -592,6 +602,7 @@ class MarkdownStyleSheet {
         typedOther.blockSpacing == blockSpacing &&
         typedOther.listIndent == listIndent &&
         typedOther.listBullet == listBullet &&
+        typedOther.listBulletPadding == listBulletPadding &&
         typedOther.tableHead == tableHead &&
         typedOther.tableBody == tableBody &&
         typedOther.tableHeadAlign == tableHeadAlign &&
@@ -639,6 +650,7 @@ class MarkdownStyleSheet {
       blockSpacing,
       listIndent,
       listBullet,
+      listBulletPadding,
       tableHead,
       tableBody,
       tableHeadAlign,

--- a/test/style_sheet_test.dart
+++ b/test/style_sheet_test.dart
@@ -271,5 +271,34 @@ void defineTests() {
         expect(text1.text, isNot(text2.text));
       },
     );
+
+    testWidgets(
+      'use stylesheet option listBulletPadding',
+      (WidgetTester tester) async {
+        final paddingX = 20.0;
+        final MarkdownStyleSheet style = MarkdownStyleSheet(
+            listBulletPadding: EdgeInsets.symmetric(horizontal: paddingX));
+
+        await tester.pumpWidget(
+          boilerplate(
+            Markdown(
+              data: '1. Bullet\n 2. Bullet\n * Bullet',
+              styleSheet: style,
+            ),
+          ),
+        );
+
+        List<Padding> paddings =
+            tester.widgetList<Padding>(find.byType(Padding)).toList();
+
+        expect(paddings.length, 3);
+        expect(
+          paddings.every(
+            (p) => p.padding.along(Axis.horizontal) == paddingX * 2,
+          ),
+          true,
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
This PR adds the stylesheet option `listBulletPadding` as requested by https://github.com/flutter/flutter_markdown/issues/254.

Just now I stumbled upon this PR https://github.com/flutter/flutter_markdown/pull/301, which tries to achieve the same thing. 
I would prefer the addition to the stylesheet type this PR provides: 

`MarkdownStyleSheet(listBulletPadding: EdgeInsets.only(right: 8));`



