### PR TITLE
fix blockquote inline styling

### DIFF
--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -296,7 +296,7 @@ class MarkdownBuilder implements md.NodeVisitor {
       child = _buildRichText(
         TextSpan(
           style: _isInBlockquote
-              ? _inlines.last.style!.merge(styleSheet.blockquote)
+              ? styleSheet.blockquote!.merge(_inlines.last.style)
               : _inlines.last.style,
           text: _isInBlockquote ? text.text : trimText(text.text),
           recognizer: _linkHandlers.isNotEmpty ? _linkHandlers.last : null,

--- a/test/blockquote_test.dart
+++ b/test/blockquote_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -22,6 +23,83 @@ void defineTests() {
 
         final Iterable<Widget> widgets = tester.allWidgets;
         expectTextStrings(widgets, <String>['quote']);
+      },
+    );
+
+    testWidgets(
+      'should work with styling',
+      (WidgetTester tester) async {
+        final ThemeData theme = ThemeData.light().copyWith(
+          textTheme: textTheme,
+        );
+        final MarkdownStyleSheet styleSheet = MarkdownStyleSheet.fromTheme(
+          theme,
+        );
+
+        const String data =
+            '> this is a link: [Markdown guide](https://www.markdownguide.org) and this is **bold** and *italic*';
+        await tester.pumpWidget(
+          boilerplate(
+            MarkdownBody(
+              data: data,
+              styleSheet: styleSheet,
+            ),
+          ),
+        );
+
+        final Iterable<Widget> widgets = tester.allWidgets;
+        final DecoratedBox blockQuoteContainer = tester.widget(
+          find.byType(DecoratedBox),
+        );
+        final RichText qouteText = tester.widget(find.byType(RichText));
+        final List<TextSpan> styledTextParts =
+            (qouteText.text as TextSpan).children!.cast<TextSpan>();
+
+        expectTextStrings(
+          widgets,
+          ['this is a link: Markdown guide and this is bold and italic'],
+        );
+        expect(
+          (blockQuoteContainer.decoration as BoxDecoration).color,
+          (styleSheet.blockquoteDecoration as BoxDecoration).color,
+        );
+        expect(
+          (blockQuoteContainer.decoration as BoxDecoration).borderRadius,
+          (styleSheet.blockquoteDecoration as BoxDecoration).borderRadius,
+        );
+
+        /// this is a link
+        expect(styledTextParts[0].text, 'this is a link: ');
+        expect(
+          styledTextParts[0].style!.color,
+          theme.textTheme.bodyText2!.color,
+        );
+
+        /// Markdown guide
+        expect(styledTextParts[1].text, 'Markdown guide');
+        expect(styledTextParts[1].style!.color, Colors.blue);
+
+        /// and this is
+        expect(styledTextParts[2].text, ' and this is ');
+        expect(
+          styledTextParts[2].style!.color,
+          theme.textTheme.bodyText2!.color,
+        );
+
+        /// bold
+        expect(styledTextParts[3].text, 'bold');
+        expect(styledTextParts[3].style!.fontWeight, FontWeight.bold);
+
+        /// and
+        expect(styledTextParts[4].text, ' and ');
+        expect(
+          styledTextParts[4].style!.color,
+          theme.textTheme.bodyText2!.color,
+        );
+
+        /// italic
+        expect(styledTextParts[5].text, 'italic');
+        expect(styledTextParts[5].style!.fontStyle, FontStyle.italic);
       },
     );
   });


### PR DESCRIPTION
This PR fixes the issue that text inside a blockquote is not formatted correctly. It is always formatted as a parapraph.


**Test plan (required)**
Added a new test `should work with styling` into `blockquote_test`. It uses the markdown from #172 to test nested formatting.

**Closing issues**
#172 
#239 

**Additional considerations**
Non.
